### PR TITLE
Modernize and update to 4.17

### DIFF
--- a/app/FilterTool.js
+++ b/app/FilterTool.js
@@ -59,7 +59,7 @@ define([
     queryTools, applyRenderer,
     chartMaker, barMaker
 ) {
-    return Accessor.createSubclass({
+        return Accessor.createSubclass({
             declaredClass: "c-through.FilterTool",
 
             constructor: function (params) {

--- a/app/FilterTool.js
+++ b/app/FilterTool.js
@@ -31,7 +31,7 @@
  */
 
 define([
-    "esri/core/declare",
+    "esri/core/Accessor",
     "esri/tasks/support/Query",
 
     "dojo/dom-construct",
@@ -53,13 +53,15 @@ define([
 
 
 ], function (
-    declare, Query,
+    Accessor, Query,
     domCtr, win, dom, domStyle, on,
     parser, registry, TextBox, Button, dijit,
     queryTools, applyRenderer,
     chartMaker, barMaker
 ) {
-        return declare(null, {
+    return Accessor.createSubclass({
+            declaredClass: "c-through.FilterTool",
+
             constructor: function (params) {
 
                 this.container = params.container;

--- a/app/HighlightTool.js
+++ b/app/HighlightTool.js
@@ -49,8 +49,9 @@ define([
     domCtr, win, dom, on,
     VizTool, FilterTool, queryTools
 ) {
-    return Accessor.createSubclass({
-        declaredClass: "c-through.HighlightTool",
+        return Accessor.createSubclass({
+            declaredClass: "c-through.HighlightTool",
+
             constructor: function (params) {
 
                 this.container = params.container;

--- a/app/HighlightTool.js
+++ b/app/HighlightTool.js
@@ -32,7 +32,7 @@
  */
 
 define([
-    "esri/core/declare",
+    "esri/core/Accessor",
     "esri/tasks/support/Query",
 
     "dojo/dom-construct",
@@ -45,11 +45,12 @@ define([
     "c-through/support/queryTools"
 
 ], function (
-    declare, Query,
+    Accessor, Query,
     domCtr, win, dom, on,
     VizTool, FilterTool, queryTools
 ) {
-        return declare(null, {
+    return Accessor.createSubclass({
+        declaredClass: "c-through.HighlightTool",
             constructor: function (params) {
 
                 this.container = params.container;
@@ -161,7 +162,7 @@ define([
                             }
                         }
 
-                    }.bind(this)).otherwise(function (err) {
+                    }.bind(this)).catch(function (err) {
                         console.error(err);
                     });
                 }.bind(this));
@@ -187,7 +188,7 @@ define([
 
                     callback(buildingID);
 
-                }.bind(this)).otherwise(function (err) {
+                }.bind(this)).catch(function (err) {
                     console.error(err);
                 });
             }

--- a/app/ToolsMenu.js
+++ b/app/ToolsMenu.js
@@ -31,7 +31,7 @@
  */
 
 define([
-    "esri/core/declare",
+    "esri/core/Accessor",
 
     "dojo/dom-construct",
     "dojo/_base/window",
@@ -42,12 +42,13 @@ define([
     "c-through/FilterTool"
 
 ], function (
-    declare,
+    Accessor,
     domCtr, win, dom,
     HighlightTool, VizTool, FilterTool
 ) {
 
-        return declare(null, {
+        return Accessor.createSubclass({
+            declaredClass: "c-through.ToolsMenu",
             constructor: function (params) {
 
                 this.settings = params.config;

--- a/app/ToolsMenu.js
+++ b/app/ToolsMenu.js
@@ -46,9 +46,9 @@ define([
     domCtr, win, dom,
     HighlightTool, VizTool, FilterTool
 ) {
-
         return Accessor.createSubclass({
             declaredClass: "c-through.ToolsMenu",
+
             constructor: function (params) {
 
                 this.settings = params.config;

--- a/app/VizTool.js
+++ b/app/VizTool.js
@@ -56,6 +56,7 @@ define([
 ) {
         return Accessor.createSubclass({
             declaredClass: "c-through.VizTool",
+
             constructor: function (params) {
 
                 this.container = params.container;

--- a/app/VizTool.js
+++ b/app/VizTool.js
@@ -30,7 +30,7 @@
  */
 
 define([
-    "esri/core/declare",
+    "esri/core/Accessor",
     "esri/tasks/support/Query",
 
     "dojo/dom-construct",
@@ -48,13 +48,14 @@ define([
     "c-through/support/queryTools"
 
 ], function (
-    declare, Query,
+    Accessor, Query,
     domCtr, win, dom, domStyle, on,
     applyRenderer,
     chartMaker, barMaker, statsMaker,
     queryTools
 ) {
-        return declare(null, {
+        return Accessor.createSubclass({
+            declaredClass: "c-through.VizTool",
             constructor: function (params) {
 
                 this.container = params.container;
@@ -196,7 +197,7 @@ define([
 
                     }.bind(this));
 
-                }.bind(this)).otherwise(function (err) {
+                }.bind(this)).catch(function (err) {
                     console.error(err);
                 });
             },

--- a/app/app.js
+++ b/app/app.js
@@ -36,7 +36,7 @@
  */
 
 define([
-    "esri/core/declare",
+    "esri/core/Accessor",
     "esri/config",
 
     "esri/WebScene",
@@ -60,7 +60,7 @@ define([
     "c-through/support/queryTools"
 
 ], function (
-    declare, esriConfig,
+    Accessor, esriConfig,
     WebScene, SceneView, SceneLayer, Basemap,
     BasemapToggle, Home,
     dom, on, domCtr, win, domStyle,
@@ -99,7 +99,8 @@ define([
                 ]
         };
 
-        return declare(null, {
+        return Accessor.createSubclass({
+            declaredClass: "c-through.App",
 
             constructor: function () {
 
@@ -214,7 +215,7 @@ define([
                         });
                     }.bind(this));
 
-                }.bind(this)).otherwise(function (err) {
+                }.bind(this)).catch(function (err) {
                     console.error(err);
                 });
 

--- a/app/support/applyRenderer.js
+++ b/app/support/applyRenderer.js
@@ -21,15 +21,12 @@
    */
 
 define([
-    "esri/core/declare",
-
     "esri/renderers/SimpleRenderer",
     "esri/symbols/MeshSymbol3D",
     "esri/symbols/FillSymbol3DLayer",
     "esri/renderers/UniqueValueRenderer"
 
 ], function (
-    declare,
     SimpleRenderer,
     MeshSymbol3D,
     FillSymbol3DLayer,

--- a/app/support/barMaker.js
+++ b/app/support/barMaker.js
@@ -21,7 +21,6 @@
    */
 
 define([
-    "esri/core/declare",
     "esri/tasks/support/Query",
 
     "dojo/dom-construct",
@@ -33,7 +32,7 @@ define([
     "c-through/support/queryTools"
 
 ], function (
-    declare, Query,
+    Query,
     domCtr, win, on, dom,
     applyRenderer, queryTools
 ) {

--- a/app/support/chartMaker.js
+++ b/app/support/chartMaker.js
@@ -21,15 +21,12 @@
    */
 
 define([
-    "esri/core/declare",
-
     "dojo/dom-construct",
     "dojo/_base/window",
 
     "c-through/support/applyRenderer"
 
 ], function (
-    declare,
     domCtr, win,
     applyRenderer
 ) {

--- a/app/support/queryTools.js
+++ b/app/support/queryTools.js
@@ -21,11 +21,9 @@
    */
 
 define([
-    "esri/core/declare",
     "esri/tasks/support/Query"
 
 ], function (
-    declare,
     Query
 
 ) {
@@ -63,7 +61,7 @@ define([
 
                     callback(values);
 
-                }.bind(this)).otherwise(function (err) {
+                }.bind(this)).catch(function (err) {
                     console.error(err);
                 });
 
@@ -92,7 +90,7 @@ define([
                     else {
                         callback(currentResult, index);
                     }
-                }.bind(this)).otherwise(function(e){
+                }.bind(this)).catch(function(e){
                     console.error(e);
                 });
             }

--- a/app/support/statsMaker.js
+++ b/app/support/statsMaker.js
@@ -21,8 +21,6 @@
    */
 
 define([
-    "esri/core/declare",
-
     "dojo/dom-construct",
     "dojo/_base/window",
     "dojo/dom",
@@ -34,7 +32,6 @@ define([
     "esri/tasks/support/Query"
 
 ], function (
-    declare,
     domCtr, win, dom,
     applyRenderer,
     chartMaker,

--- a/app/welcome.js
+++ b/app/welcome.js
@@ -30,7 +30,7 @@
  */
 
 define([
-    "esri/core/declare",
+    "esri/core/Accessor",
 
     "dojo/dom-construct",
     "dojo/_base/window",
@@ -42,11 +42,12 @@ define([
     "c-through/app"
 
 ], function (
-    declare,
+    Accessor,
     domCtr, win, dom, domStyle, on, mouse,
     App) {
 
-        return declare(null, {
+        return Accessor.createSubclass({
+            declaredClass: "c-through.Welcome",
 
             constructor: function () {
                 

--- a/index.html
+++ b/index.html
@@ -26,9 +26,9 @@
   <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
   <title>c-through</title>
 
-  <!-- ArcGIS JavaScript API 4.7 stylesheet -->
-  <link rel="stylesheet" href="https://js.arcgis.com/4.13/esri/css/main.css">
-  <link rel="stylesheet" href="https://js.arcgis.com/4.13/dijit/themes/claro/claro.css" />
+  <!-- ArcGIS JavaScript API 4.17 stylesheet -->
+  <link rel="stylesheet" href="https://js.arcgis.com/4.17/esri/css/main.css">
+  <link rel="stylesheet" href="https://js.arcgis.com/4.17/dijit/themes/claro/claro.css" />
   <!-- calcite-web -->
   <link rel="stylesheet" href="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/1.0.0-beta.31/css/calcite-web.min.css">
 
@@ -53,8 +53,8 @@
         async: true
     };
   </script>
-  <!-- ArcGIS JavaScript API 4.13  -->
-  <script src="https://js.arcgis.com/4.13/"></script>
+  <!-- ArcGIS JavaScript API 4.17  -->
+  <script src="https://js.arcgis.com/4.17/"></script>
   <!-- load app.js -->
   <script>
   require(["c-through/welcome",  "dojo/domReady!"],function(Welcome){


### PR DESCRIPTION
Updates to make c-through work with the latest ArcGIS JS API version:

* Use Accessor.createSubclass instead of declare
* Use catch instead of otherwise